### PR TITLE
Abstract the Dark Sky API URL into the config file

### DIFF
--- a/src/Adapters/Laravel/config/dark-sky-api.php
+++ b/src/Adapters/Laravel/config/dark-sky-api.php
@@ -19,6 +19,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | API Base Url
+    |--------------------------------------------------------------------------
+    |
+    | The base URL endpoint to access the Dark Sky API.
+    | Can be replaced with other compatible services.
+    | No trailing slash should be appended, thanks.
+    |
+    | @link https://darksky.net/dev/
+    |
+    */
+
+    'baseUrl' => 'https://api.darksky.net',
+
+    /*
+    |--------------------------------------------------------------------------
     | Language
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Request/UrlGenerator.php
+++ b/src/Http/Request/UrlGenerator.php
@@ -51,7 +51,7 @@ class UrlGenerator
         $latitude = number_format($latitude, 3);
         $longitude = number_format($longitude, 3);
 
-        return new Url("https://api.darksky.net/forecast/{$key}/{$latitude},{$longitude}");
+        return new Url(config('dark-sky-api.baseUrl') . "/forecast/{$key}/{$latitude},{$longitude}");
     }
 
     /**

--- a/tests/Http/Stubs/Parameters/DefaultStub.php
+++ b/tests/Http/Stubs/Parameters/DefaultStub.php
@@ -35,7 +35,7 @@ class DefaultStub extends AbstractStub
      */
     public function expectedUrl()
     {
-        return new Url('https://api.darksky.net/forecast/api-key-12345/1.234,5.678');
+        return new Url(config('dark-sky-api.baseUrl') . '/forecast/api-key-12345/1.234,5.678');
     }
 
     /**


### PR DESCRIPTION
With the full retirement of the DarkSky here, I wanted to swap in the [Pirate Weather](https://pirateweather.net) API while continuing to use this library. The only thing stopping me was the hardcoded Dark Sky API endpoint, so this PR abstracts that into the config file. As it's currently set up it would be a breaking change without republishing the config file, so wanted to see how you'd like to handle that, if you accept this PR as useful in the first place.
